### PR TITLE
Update get-cursor-position

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "ansi.js": "0.0.5",
     "end-with": "^1.0.2",
-    "get-cursor-position": "1.0.1",
+    "get-cursor-position": "1.0.2",
     "on-new-line": "1.0.0",
     "start-with": "^1.0.2"
   }


### PR DESCRIPTION
Fixes an issue that breaks this module on case-sensitive (Unix) filesystems
