### PR TITLE
little typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ npm install ascii-progress
 var ProgressBar = require('ascii-progress');
 
 var bar = new ProgressBar({ 
-    schema: ':bar'
+    schema: ':bar',
     total : 10 
 });
 


### PR DESCRIPTION
Missed ',' in usage
