### PR TITLE
Fix: case when stdout did not have rows/columns defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var getCurosrPos = require('get-cursor-position');
 var newlineEvent = require('on-new-line');
 
 var stream      = process.stdout;
+stream.rows     = stream.rows || 40;
+stream.columns  = stream.columns || 80;
+
 var placeholder = '\uFFFC';
 var rendering   = false;
 var instances   = [];


### PR DESCRIPTION
In WebStorm or when piping the app `node index.js > debug.log` there are no rows/columns, so we default to 40/80
