### PR TITLE
Cut off output

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ stream.on('before:newlines', function (count) {
   }
 
   var current = getCurosrPos.sync();
+  if(!current){
+    return;
+  }
+  
   // did not reach the end, the screen need not scroll up
   if (current.row < stream.rows) {
     return;

--- a/index.js
+++ b/index.js
@@ -275,6 +275,16 @@ ProgressBar.prototype.render = function (output) {
 
 ProgressBar.prototype.colorize = function (output) {
 
+  var charsLeft = process.stdout.columns - 1;
+  function writeChars (chars) {
+    if (!charsLeft) {
+      return;
+    }
+
+    cursor.write(chars.slice(0, charsLeft));
+    charsLeft = Math.max(0, charsLeft - chars.length);
+  }
+
   var cursor  = this.cursor;
   var parts   = output.split(/(\.[A-Za-z]+)/g);
   var content = '';
@@ -329,11 +339,11 @@ ProgressBar.prototype.colorize = function (output) {
             : interpolate(color1, color2, (i + 1) / l);
 
           cursor.fg.rgb(color.r, color.g, color.b);
-          cursor.write(content[i]);
+          writeChars(content[i]);
           cursor.fg.reset();
         }
       } else {
-        cursor.write(content);
+        writeChars(content);
       }
     }
 
@@ -386,7 +396,7 @@ ProgressBar.prototype.colorize = function (output) {
           parts[i + 1] += match.suffix;
         } else {
           // the last one
-          cursor.write(match.suffix);
+          writeChars(match.suffix);
         }
       }
 


### PR DESCRIPTION
Hacky way to cut-off output when it exceeds column length (hard to do this nicely due to lack of parsed structure).