### PR TITLE
Add null check to avoid breaking when there is no tty

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,7 +456,9 @@ ProgressBar.prototype.terminate = function () {
   }
 
   this.callback && this.callback(this);
-  this.cursor.moveTo(this.savePos.row, this.savePos.col);
+  if (this.savePos) {
+    this.cursor.moveTo(this.savePos.row, this.savePos.col);
+  }
 };
 
 


### PR DESCRIPTION
I'm getting this error when running a code that uses ascii-progress inside docker with no tty attached:

```
node_modules/ascii-progress/index.js:459
  this.cursor.moveTo(this.savePos.row, this.savePos.col);
                                 ^

TypeError: Cannot read property 'row' of undefined
```

I believe the issue is that `get-cursor-position` returns null when you don't have a tty, so I've added a null check in this line.

Probably same reason of #14 